### PR TITLE
feat: parse pickup number from remarks

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,12 +1,14 @@
 from pydantic import BaseModel
-from typing import List
+from typing import List, Optional
 from datetime import datetime
+
 
 class DeliveryStop(BaseModel):
     po_number: str
     store: str
     address: str
     datetime: datetime
+
 
 class PDFResponse(BaseModel):
     sid: str
@@ -15,7 +17,10 @@ class PDFResponse(BaseModel):
     pickup_address: str
     pickup_datetime: datetime
     deliveries: List[DeliveryStop]
+    pickup_number: Optional[str] = None
     unmatched_stores: List[str] = []
+
 
 class PDFRequest(BaseModel):
     fileUrl: str
+

--- a/parser_module.py
+++ b/parser_module.py
@@ -103,13 +103,23 @@ def extract_order_info(pdf_stream) -> PDFResponse:
                     )
                 )
 
+    # --- Parse PU# in Remarks section ---
+    pickup_number = "-"
+    for i, line in enumerate(lines):
+        if line.strip().upper() == "REMARKS":
+            next_line = find_next_non_empty(lines, i + 1)
+            if next_line and next_line != "•":
+                pickup_number = next_line.strip()
+            break
+
     return PDFResponse(
         sid=sid,
         order_number=order,
         pickup_location=pickup_location,
         pickup_address=pickup_address,
         pickup_datetime=pickup_datetime,
-        deliveries=deliveries
+        deliveries=deliveries,
+        pickup_number=pickup_number,
     )
 
 # Test runner
@@ -119,3 +129,4 @@ if __name__ == "__main__":
         pdf_stream = BytesIO(f.read())
         data = extract_order_info(pdf_stream)
         print(data.model_dump_json(indent=2))
+


### PR DESCRIPTION
## Summary
- include optional `pickup_number` in PDFResponse model
- scan PDF text for Remarks section and extract pickup number

## Testing
- `python parser_module.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3dff11b90832b99081e26fd561302